### PR TITLE
feature: Link를 사용하여 바깥쪽 post wrapper 클릭시 라우팅 이동

### DIFF
--- a/src/components/blog/post-wrapper.tsx
+++ b/src/components/blog/post-wrapper.tsx
@@ -87,9 +87,11 @@ const getGridType = (gridType: number) => {
 const PostWrapper = ({
   children,
   gridType,
+  onClick,
 }: {
   children: JSX.Element
   gridType: number
+  onClick: () => void
 }): JSX.Element => {
   return (
     <StyledPostWrapper sizes={sizes} colors={colors} gridType={gridType}>

--- a/src/components/blog/post-wrapper.tsx
+++ b/src/components/blog/post-wrapper.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, forwardRef, PropsWithChildren } from 'react'
 import styled, { css } from 'styled-components'
 
 import { sizes, colors } from '@/styles'
@@ -84,23 +84,25 @@ const getGridType = (gridType: number) => {
   }
 }
 
-const PostWrapper = ({
-  children,
-  gridType,
-  onClick,
-}: {
+interface WrapperPropType {
   children: JSX.Element
   gridType: number
-  onClick: () => void
-}): JSX.Element => {
+}
+
+const PostWrapper = forwardRef<
+  HTMLAnchorElement,
+  PropsWithChildren<WrapperPropType>
+>(function (props: WrapperPropType, ref): JSX.Element {
+  const { children } = props
+
   return (
-    <StyledPostWrapper sizes={sizes} colors={colors} gridType={gridType}>
+    <StyledPostWrapper ref={ref} {...props} colors={colors}>
       {children}
     </StyledPostWrapper>
   )
-}
+})
 
-const StyledPostWrapper = styled.div`
+const StyledPostWrapper = styled.a`
   background-color: ${(props) => props.colors.primary};
   padding: 1rem;
   border: 0.01rem solid black;

--- a/src/components/blog/post.tsx
+++ b/src/components/blog/post.tsx
@@ -20,9 +20,7 @@ const Post = ({ post }: { post: PostType }): JSX.Element => {
       <h3>
         <span>
           {!post.Published && <span>Draft</span>}
-          <a>
-            <PostTitle sizes={sizes}>{post.Page}</PostTitle>
-          </a>
+          <PostTitle sizes={sizes}>{post.Page}</PostTitle>
         </span>
       </h3>
       {post.Authors?.length > 0 && post.Date && (

--- a/src/components/blog/post.tsx
+++ b/src/components/blog/post.tsx
@@ -20,11 +20,9 @@ const Post = ({ post }: { post: PostType }): JSX.Element => {
       <h3>
         <span>
           {!post.Published && <span>Draft</span>}
-          <Link href="/blog/[slug]" as={getBlogLink(post.Slug)}>
-            <a>
-              <PostTitle sizes={sizes}>{post.Page}</PostTitle>
-            </a>
-          </Link>
+          <a>
+            <PostTitle sizes={sizes}>{post.Page}</PostTitle>
+          </a>
         </span>
       </h3>
       {post.Authors?.length > 0 && post.Date && (

--- a/src/pages/blog/[slug].tsx
+++ b/src/pages/blog/[slug].tsx
@@ -170,7 +170,10 @@ const RenderPost = ({
       )}
       {postPageCover && (
         <div className={blogStyles.coverImg}>
-          <img src={postPageCover} alt="page-cover-image" />
+          <img
+            src={postPageCover ? postPageCover : ''}
+            alt="page-cover-image"
+          />
         </div>
       )}
 

--- a/src/pages/blog/index.tsx
+++ b/src/pages/blog/index.tsx
@@ -1,9 +1,5 @@
 import Link from 'next/link'
-import Header from '@/components/header'
-import PostWrapper from '@/components/blog/post-wrapper'
-import Post from '@/components/blog/post'
-import Grid from '@/components/blog/grid'
-import Layout from '@/components/layout'
+import { useRouter } from 'next/router'
 
 import blogStyles from '@/styles/blog.module.css'
 import { getBlogLink, getDateStr, postIsPublished } from '@/lib/blog-helpers'
@@ -11,6 +7,12 @@ import { textBlock } from '@/lib/notion/renderers'
 import getNotionUsers from '@/lib/notion/getNotionUsers'
 import getBlogIndex from '@/lib/notion/getBlogIndex'
 import { PostType } from '@/types/common'
+
+import Header from '@/components/header'
+import PostWrapper from '@/components/blog/post-wrapper'
+import Post from '@/components/blog/post'
+import Grid from '@/components/blog/grid'
+import Layout from '@/components/layout'
 
 export async function getStaticProps({ preview }) {
   const postsTable = await getBlogIndex()
@@ -53,9 +55,12 @@ const Index = ({
   posts: PostType[]
   preview?: string
 }) => {
-  const onClickPost = (post: PostType) => {
-    ;`/blog/${getBlogLink(post.Slug)}`
-  }
+  const router = useRouter()
+
+  // const onClickPost = (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>, slug: string) => {
+  //   console.log('onClickPost', slug)
+  //   router.push(`/blog/${getBlogLink(slug)}`)
+  // }
 
   return (
     <>
@@ -77,13 +82,15 @@ const Index = ({
           {posts.map(
             (post: PostType, index: number): JSX.Element => {
               return (
-                <PostWrapper
-                  key={`post-wrapper-${index}`}
-                  gridType={index < 11 ? index : index - 10}
-                  onClick={() => onClickPost(post)}
+                <Link
+                  key={post.Slug}
+                  href={`${getBlogLink(post.Slug)}`}
+                  passHref
                 >
-                  <Post post={post} />
-                </PostWrapper>
+                  <PostWrapper gridType={index < 11 ? index : index - 10}>
+                    <Post post={post} />
+                  </PostWrapper>
+                </Link>
               )
             }
           )}

--- a/src/pages/blog/index.tsx
+++ b/src/pages/blog/index.tsx
@@ -53,6 +53,10 @@ const Index = ({
   posts: PostType[]
   preview?: string
 }) => {
+  const onClickPost = (post: PostType) => {
+    ;`/blog/${getBlogLink(post.Slug)}`
+  }
+
   return (
     <>
       <Header titlePre="Blog" />
@@ -74,8 +78,9 @@ const Index = ({
             (post: PostType, index: number): JSX.Element => {
               return (
                 <PostWrapper
-                  key={`postwrapper-${index}`}
+                  key={`post-wrapper-${index}`}
                   gridType={index < 11 ? index : index - 10}
+                  onClick={() => onClickPost(post)}
                 >
                   <Post post={post} />
                 </PostWrapper>

--- a/src/styles/blog.module.css
+++ b/src/styles/blog.module.css
@@ -98,6 +98,7 @@
   height: 16rem;
   object-fit: cover;
   overflow: hidden;
+  background-color: var(--primary);
 }
 
 .coverImg > img {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -9,8 +9,8 @@
   --grey-1: #111;
   --grey-2: #333;
   --grey-3: rgb(71, 71, 71);
-  --primary: #bbc40f;
-  --primary-dark: #a9ac0d;
+  --primary: #fcfce7;
+  --primary-dark: #e9e9cc;
   --geist-foreground: #000;
 
   --radius: 8px;


### PR DESCRIPTION
Before
- blog페이지에서 타이틀을 클릭해야지만 해당 페이지로 이동하였음

After
- Link를 사용하여 바깥쪽 post wrapper(노랑 블록) 클릭시 라우팅 이동
- PostWrapper props, children 타입 정의